### PR TITLE
fixes issues with adding pages below two levels

### DIFF
--- a/tpl/main.php
+++ b/tpl/main.php
@@ -243,7 +243,7 @@ function init_index()
         if ( pattern.test(links[i].className) ) {
             links[i].href += '&npd=1';
             var a = links[i].href.replace(/.*idx=:?([^&]*).*/, "$1");
-            a = a.replace(/%3A/, ":");
+            a = a.replace(/%3A/g, ":");
             if (a == jQuery('#npd_ns').val()) {
                 links[i].className += " active";
                 active = links[i];


### PR DESCRIPTION
Originally this only replaced the first %3A with a colon. This prevented you from adding a page in any namespace that was more than two levels embedded, and also prevented such namespaces from being set to be part of the 'active' class. This fix makes the change globally, replacing all %3A.