### PR TITLE
fix method signature bug which leads to crashes in DokuWiki Release 2020-07-29 "Hogfather"

### DIFF
--- a/action/meta.php
+++ b/action/meta.php
@@ -16,7 +16,7 @@ class action_plugin_npd_meta extends DokuWiki_Action_Plugin {
         return confToHash(dirname(__FILE__).'../plugin.info.txt');
     }
 
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'meta');
     }

--- a/action/new.php
+++ b/action/new.php
@@ -19,7 +19,7 @@ class action_plugin_npd_new extends DokuWiki_Action_Plugin {
         return confToHash(dirname(__FILE__).'../plugin.info.txt');
     }
 
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, 'fckw_index');
     }


### PR DESCRIPTION
This PlugIn caused DokuWiki to crash after updating to 2020-07-29 "Hogfather" because of an old method signature.

Issue is described here: patreon.com/posts/declaration-be-20638123

Please accept the pull request to make this PlugIn usable for neewr DokuWiki releases.

Greetings

